### PR TITLE
Re-add squeal-postgresql

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3205,7 +3205,7 @@ packages:
         - blas-hs
 
     "Eitan Chatav <eitan@gmail.com> @echatav":
-        - squeal-postgresql < 0 # https://github.com/morphismtech/squeal/issues/30
+        - squeal-postgresql
 
     "Sam Quinn <lazersmoke@gmail.com> @Lazersmoke":
         - ghost-buster


### PR DESCRIPTION
Re-add `squeal-postgresql`. Fixed issue https://github.com/morphismtech/squeal/issues/30 in pull request https://github.com/morphismtech/squeal/pull/33.

Checklist:
- [x] Meaningful commit message - please not `Update build-constraints.yml`
- [x] At least 30 minutes have passed since Hackage upload
- [x] On your own machine, in a new directory, you have successfully run the following set of commands (replace `$package` with the name of the package that is submitted, `$version` is the version of the package you want to get into Stackage):

      stack unpack $package-$version
      cd $package-$version
      stack init --resolver nightly
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
